### PR TITLE
Added ingress-nginx usage information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ Global Flags:
 
 ## Known Users
 - [stable/prometheus-operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) helm chart
+- [ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) helm chart


### PR DESCRIPTION
Image from this repo also used in ingress-nginx controller [ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx)
I guess this info also can be added to `Known Users` section