### PR TITLE
proper apiversion for kubernetes > v1.22

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jet/kube-webhook-certgen/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 var (
@@ -29,7 +29,7 @@ func prePatchCommand(cmd *cobra.Command, args []string) {
 		break
 	case "Ignore":
 	case "Fail":
-		failurePolicy = admissionv1beta1.FailurePolicyType(cfg.patchFailurePolicy)
+		failurePolicy = admissionv1.FailurePolicyType(cfg.patchFailurePolicy)
 		break
 	default:
 		log.Fatalf("patch-failure-policy %s is not valid", cfg.patchFailurePolicy)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/onrik/logrus/filename"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"os"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 )
 
 var (
@@ -33,7 +34,7 @@ var (
 		kubeconfig         string
 	}{}
 
-	failurePolicy admissionv1beta1.FailurePolicyType
+	failurePolicy admissionv1.FailurePolicyType
 )
 
 // Execute is the main entry point for the program

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -2,9 +2,10 @@ package k8s
 
 import (
 	"context"
+
 	log "github.com/sirupsen/logrus"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/core/v1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,14 +34,14 @@ func New(kubeconfig string) *k8s {
 // the provided ca data. If failurePolicy is provided, patch all webhooks with this value
 func (k8s *k8s) PatchWebhookConfigurations(
 	configurationNames string, ca []byte,
-	failurePolicy *admissionv1beta1.FailurePolicyType,
+	failurePolicy *admissionv1.FailurePolicyType,
 	patchMutating bool, patchValidating bool) {
 
 	log.Infof("patching webhook configurations '%s' mutating=%t, validating=%t, failurePolicy=%s", configurationNames, patchMutating, patchValidating, *failurePolicy)
 
 	if patchValidating {
 		valHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 
@@ -56,7 +57,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			ValidatingWebhookConfigurations().
 			Update(context.TODO(), valHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")
@@ -68,7 +69,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 
 	if patchMutating {
 		mutHook, err := k8s.clientset.
-			AdmissionregistrationV1beta1().
+			AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Get(context.TODO(), configurationNames, metav1.GetOptions{})
 		if err != nil {
@@ -83,7 +84,7 @@ func (k8s *k8s) PatchWebhookConfigurations(
 			}
 		}
 
-		if _, err = k8s.clientset.AdmissionregistrationV1beta1().
+		if _, err = k8s.clientset.AdmissionregistrationV1().
 			MutatingWebhookConfigurations().
 			Update(context.TODO(), mutHook, metav1.UpdateOptions{}); err != nil {
 			log.WithField("err", err).Fatal("failed patching validating webhook")

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -3,13 +3,13 @@ package k8s
 import (
 	"bytes"
 	"context"
-	"k8s.io/api/admissionregistration/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 	"math/rand"
 	"testing"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 const (
@@ -19,8 +19,8 @@ const (
 )
 
 var (
-	fail   = admissionv1beta1.Fail
-	ignore = admissionv1beta1.Ignore
+	fail   = admissionv1.Fail
+	ignore = admissionv1.Ignore
 )
 
 func genSecretData() (ca, cert, key []byte) {
@@ -92,29 +92,29 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	ca, _, _ := genSecretData()
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.MutatingWebhookConfiguration{
+		Create(context.Background(), &v1.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
+			Webhooks: []v1.MutatingWebhook{{Name: "m1"}, {Name: "m2"}}}, metav1.CreateOptions{})
 
 	k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		ValidatingWebhookConfigurations().
-		Create(context.Background(), &v1beta1.ValidatingWebhookConfiguration{
+		Create(context.Background(), &v1.ValidatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testWebhookName,
 			},
-			Webhooks: []v1beta1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
+			Webhooks: []v1.ValidatingWebhook{{Name: "v1"}, {Name: "v2"}}}, metav1.CreateOptions{})
 
 	k.PatchWebhookConfigurations(testWebhookName, ca, &fail, true, true)
 
 	whmut, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 
@@ -123,7 +123,7 @@ func TestPatchWebhookConfigurations(t *testing.T) {
 	}
 
 	whval, err := k.clientset.
-		AdmissionregistrationV1beta1().
+		AdmissionregistrationV1().
 		MutatingWebhookConfigurations().
 		Get(context.Background(), testWebhookName, metav1.GetOptions{})
 


### PR DESCRIPTION
fixes `admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration ` error 